### PR TITLE
Remove upper bound on active_support version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - ruby-1.9.3
-  - ruby-2.2.1
+  - ruby-2.2.2
   - jruby-9.0.1.0
-  - jruby-1.7.20.1
 before_install: gem install bundler -v 1.10.6
 addons:
   code_climate:

--- a/ice_cube_cron.gemspec
+++ b/ice_cube_cron.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Dependencies
   #
   s.add_dependency 'ice_cube', '<= 0.13.0'
-  s.add_dependency 'activesupport', '~> 4'
+  s.add_dependency 'activesupport'
 
   ##
   # Development Dependencies


### PR DESCRIPTION
active_support 5 appears to be compatible. We are using a small set up utilities from active_support. I think it is safe to remove the upper version bound.
